### PR TITLE
Add .gitattributes based on Asset Library recommendations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings for all files that Git considers text files.
+* text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 /**        export-ignore
 /addons    !export-ignore
 /addons/** !export-ignore
+/addons/TopDownCamera2D/plugin.cfg export-subst

--- a/addons/TopDownCamera2D/plugin.cfg
+++ b/addons/TopDownCamera2D/plugin.cfg
@@ -3,5 +3,5 @@
 name="TopDownCamera2D"
 description="A smooth top-down camera solution with cursor-centric zoom and pan functionality. Features include mouse cursor-based zooming, boundary limits, and smooth transitions using interpolation."
 author="cng6sk"
-version="1.0"
+version="$Format:%(describe:tags)$"
 script="plugin.gd"


### PR DESCRIPTION
Adds [recommended](https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html#recommendations) export ignores. Also adds export substitution for the plugin version string.